### PR TITLE
Update to ort v2 alpha 1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,10 +48,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
+name = "block-buffer"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "cc"
@@ -101,6 +104,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf0a07a401f374238ab8e2f11a104d2851bf9ce711ec69804834de8af45c7af"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,19 +122,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-utils"
-version = "0.8.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "divan"
@@ -196,6 +219,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -380,8 +413,9 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "ort"
-version = "2.0.0-alpha.0"
-source = "git+https://github.com/pykeio/ort?rev=584a6e34#584a6e3479dcdc4ea97e5886f569101c758a6384"
+version = "2.0.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d06eb9400ebe2c4caf0777d1f84010f33bfad460773c09eaa7716b6dc5ffbf"
 dependencies = [
  "half",
  "ndarray",
@@ -394,13 +428,14 @@ dependencies = [
 
 [[package]]
 name = "ort-sys"
-version = "2.0.0-alpha.0"
-source = "git+https://github.com/pykeio/ort?rev=584a6e34#584a6e3479dcdc4ea97e5886f569101c758a6384"
+version = "2.0.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c1c9497f4d60c5e895e1516a7bdb76abd671738555897c38f8ac7d3c17fb225"
 dependencies = [
  "flate2",
+ "sha2",
  "tar",
  "ureq",
- "zip",
 ]
 
 [[package]]
@@ -585,6 +620,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -743,6 +789,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -800,6 +852,12 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasi"
@@ -908,16 +966,4 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4686009f71ff3e5c4dbcf1a282d0a44db3f021ba69350cd42086b3e5f1c6985"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "zip"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
-dependencies = [
- "byteorder",
- "crc32fast",
- "crossbeam-utils",
- "flate2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,11 @@ keywords = ["batch", "ort", "onnxruntime"]
 [dependencies]
 flume = { version = "0.11.0", default-features = false }
 ndarray = { version = "0.15.6", default-features = false }
-ort = { git = "https://github.com/pykeio/ort", rev = "584a6e34", default-features = false, features = ["ndarray"] }
+ort = { version = "2.0.0-alpha.1", default-features = false, features = ["ndarray"] }
 
 [dev-dependencies]
 rand = "0.8.5"
-ort = { git = "https://github.com/pykeio/ort", rev = "584a6e34", features = ["download-binaries", "fetch-models", "cuda"] }
+ort = { version = "2.0.0-alpha.1", features = ["download-binaries", "fetch-models", "cuda"] }
 divan = "0.1.2"
 ndarray-rand = "0.14.0"
 ndarray = { version = "0.15.6", features = ["approx"] }

--- a/benches/threads.rs
+++ b/benches/threads.rs
@@ -1,6 +1,6 @@
 use divan::{black_box, Bencher};
 use ndarray::{ArrayD, Axis};
-use ort::{Environment, Session, SessionBuilder, Value};
+use ort::{Session, Value};
 use ort_batcher::batcher::Batcher;
 use std::time::Duration;
 
@@ -9,8 +9,7 @@ fn main() {
 }
 
 fn load_test_model() -> ort::Result<Session> {
-    let environment = Environment::builder().build()?.into_arc();
-    let session = SessionBuilder::new(&environment)?
+    let session = Session::builder()?
         .with_intra_threads(1)?
         .with_model_from_memory(include_bytes!("../tests/model.onnx"))?;
 

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -1,16 +1,16 @@
 use ndarray::{ArrayD, Axis};
-use ort::{CUDAExecutionProvider, Environment, SessionBuilder, Value};
+use ort::{CUDAExecutionProvider, Session, Value};
 use ort_batcher::batcher::Batcher;
 use std::time::Duration;
 
 fn main() -> ort::Result<()> {
     tracing_subscriber::fmt::init();
 
-    let environment = Environment::builder()
+    ort::init()
         .with_execution_providers([CUDAExecutionProvider::default().build()])
-        .build()?
-        .into_arc();
-    let session = SessionBuilder::new(&environment)?
+        .commit()?;
+
+    let session = Session::builder()?
         .with_intra_threads(1)?
         .with_model_from_memory(include_bytes!("../tests/model.onnx"))?;
 

--- a/tests/correctness.rs
+++ b/tests/correctness.rs
@@ -1,13 +1,12 @@
 use ndarray::{ArrayD, Axis, IxDyn};
 use ndarray_rand::rand_distr::Uniform;
 use ndarray_rand::RandomExt;
-use ort::{Environment, Session, SessionBuilder, Value};
+use ort::{Session, Value};
 use ort_batcher::batcher::Batcher;
 use std::time::Duration;
 
 fn load_test_model() -> ort::Result<Session> {
-    let environment = Environment::builder().build()?.into_arc();
-    let session = SessionBuilder::new(&environment)?
+    let session = Session::builder()?
         .with_intra_threads(1)?
         .with_model_from_memory(include_bytes!("../tests/model.onnx"))?;
 


### PR DESCRIPTION
This PR updates `ort_batcher` to use the recently published ort `v2.0.0-alpha.1`. Thank you for the awesome crate!