### PR TITLE
Use runtime arguments in Divan benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,22 +149,23 @@ dependencies = [
 
 [[package]]
 name = "divan"
-version = "0.1.2"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fab20f5802e0b897093184f5dc5d23447fa715604f238dc798f6da188b230019"
+checksum = "5398159ee27f2b123d89b856bad61725442f37df5fb98c30cd570c318d594aee"
 dependencies = [
+ "cfg-if",
  "clap",
  "condtype",
  "divan-macros",
- "linkme",
+ "libc",
  "regex-lite",
 ]
 
 [[package]]
 name = "divan-macros"
-version = "0.1.2"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c5d6354551e0b5c451a948814fc47fe745a14eac7835c087d60162661019db4"
+checksum = "5092f66eb3563a01e85552731ae82c04c934ff4efd7ad1a0deae7b948f4b3ec4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -279,26 +280,6 @@ name = "libm"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
-
-[[package]]
-name = "linkme"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ed2ee9464ff9707af8e9ad834cffa4802f072caad90639c583dd3c62e6e608"
-dependencies = [
- "linkme-impl",
-]
-
-[[package]]
-name = "linkme-impl"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba125974b109d512fccbc6c0244e7580143e460895dfd6ea7f8bbb692fd94396"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "linux-raw-sys"
@@ -440,7 +421,7 @@ dependencies = [
 
 [[package]]
 name = "ort_batcher"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "divan",
  "flume",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ ort = { version = "2.0.0-alpha.1", default-features = false, features = ["ndarra
 [dev-dependencies]
 rand = "0.8.5"
 ort = { version = "2.0.0-alpha.1", features = ["download-binaries", "fetch-models", "cuda"] }
-divan = "0.1.2"
+divan = "0.1.11"
 ndarray-rand = "0.14.0"
 ndarray = { version = "0.15.6", features = ["approx"] }
 tracing-subscriber = "0.3.18"

--- a/benches/threads.rs
+++ b/benches/threads.rs
@@ -39,11 +39,11 @@ fn sequential_without_batcher_16k() {
     // number of producers
     threads = [1024],
     // batch size
-    consts = [1, 32, 64, 128, 256, 512, 1024]
+    args = [1, 32, 64, 128, 256, 512, 1024]
 )]
-fn batch_sizes_1024t_16i_16k<const MAX_BATCH_SIZE: usize>(bencher: Bencher) {
+fn batch_sizes_1024t_16i_16k(bencher: Bencher, max_batch_size: usize) {
     let session = load_test_model().unwrap();
-    let batcher = Batcher::spawn(session, MAX_BATCH_SIZE, Duration::from_millis(10));
+    let batcher = Batcher::spawn(session, max_batch_size, Duration::from_millis(10));
     let inputs = vec![ArrayD::zeros(vec![7, 8, 9])];
 
     bencher.bench(move || {


### PR DESCRIPTION
The new [`args`](https://docs.rs/divan/latest/divan/attr.bench.html#args) option greatly reduces compile times and is not limited to arrays/slices.